### PR TITLE
Portability fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: ruby
 rvm:
   - 2.2.4
-addons:
-  apt:
-    packages:
-      - librpm3

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.2.5.2'
 # Database setup.
 gem 'sqlite3'
 gem 'pg'
-gem 'activerecord-import'
+gem 'activerecord-import', '>= 0.2.0'
 
 gem 'whenever', :require => false
 
@@ -14,9 +14,6 @@ gem 'whenever', :require => false
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
-
-# The RPM gem is needed for version parsing.
-gem 'rpm'
 
 # The git gem is used to maintain a checkout of Ruby Gem advisories.
 gem 'git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,6 @@ GEM
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.14)
     git (1.3.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -156,8 +155,6 @@ GEM
     rake (11.2.2)
     rdoc (4.2.2)
       json (~> 1.4)
-    rpm (0.0.5)
-      ffi
     rspec-core (3.5.2)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -222,7 +219,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-import
+  activerecord-import (>= 0.2.0)
   byebug
   capistrano (~> 3.0)
   capistrano-bundler
@@ -235,7 +232,6 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   pg
   rails (= 4.2.5.2)
-  rpm
   rspec-rails (~> 3.0)
   sdoc (~> 0.4.0)
   sqlite3

--- a/app/models/import/packages/gems.rb
+++ b/app/models/import/packages/gems.rb
@@ -6,9 +6,6 @@ class Import::Packages::Gems
   require 'yaml'
   require 'rubygems'
   require 'logger'
-  require 'activerecord-import'
-  require 'activerecord-import/base'
-  ActiveRecord::Import.require_adapter('pg')
 
   LOGFILE       = 'log/import.log'.freeze
   LOGLEVEL      = Logger::INFO

--- a/app/models/import/packages/yum/centos.rb
+++ b/app/models/import/packages/yum/centos.rb
@@ -9,9 +9,6 @@ class Import
         require 'find'
         require 'yaml'
         require 'logger'
-        require 'activerecord-import'
-        require 'activerecord-import/base'
-        ActiveRecord::Import.require_adapter('pg')
 
         LOGFILE       = 'log/import.log'.freeze
         LOGLEVEL      = Logger::INFO

--- a/app/models/import/servers.rb
+++ b/app/models/import/servers.rb
@@ -2,9 +2,6 @@
 class Import::Servers
   require 'yaml'
   require 'logger'
-  require 'activerecord-import'
-  require 'activerecord-import/base'
-  ActiveRecord::Import.require_adapter('pg')
 
   SERVER_FILES  = '/var/lib/package-reports/*.yaml'.freeze
   LOGFILE       = 'log/import.log'.freeze


### PR DESCRIPTION
* Replaced the rpm gem with native code (borrowed from puppet) to avoid
rpmlib dependencies.
* Updated the gem for activerecord-import to a version that doesn't
require manual includes, and thus plays better with switching db types.