### PR TITLE
Portability fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: ruby
 rvm:
   - 2.2.4
-addons:
-  apt:
-    packages:
-      - librpm3

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.2.5.2'
 # Database setup.
 gem 'sqlite3'
 gem 'pg'
-gem 'activerecord-import'
+gem 'activerecord-import', '>= 0.2.0'
 
 gem 'whenever', :require => false
 
@@ -14,9 +14,6 @@ gem 'whenever', :require => false
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
-
-# The RPM gem is needed for version parsing.
-gem 'rpm'
 
 # The git gem is used to maintain a checkout of Ruby Gem advisories.
 gem 'git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,6 @@ GEM
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.14)
     git (1.3.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -156,8 +155,6 @@ GEM
     rake (11.2.2)
     rdoc (4.2.2)
       json (~> 1.4)
-    rpm (0.0.5)
-      ffi
     rspec-core (3.5.2)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -222,7 +219,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-import
+  activerecord-import (>= 0.2.0)
   byebug
   capistrano (~> 3.0)
   capistrano-bundler
@@ -235,7 +232,6 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   pg
   rails (= 4.2.5.2)
-  rpm
   rspec-rails (~> 3.0)
   sdoc (~> 0.4.0)
   sqlite3

--- a/app/helpers/rpm_helper.rb
+++ b/app/helpers/rpm_helper.rb
@@ -1,0 +1,218 @@
+# This gives helper functions for RPM version parsing and comparison.  It's
+# taken from https://github.com/puppetlabs/puppet/pull/2866/files, since there
+# are no currently maintained gems I could find that can do this in native
+# ruby.  There is one interface to RPM libraries, but it requires rpmlib
+# versions not available in brew on OS X which makes testing less easy.
+#
+# if yum_compareEVR(yum_parse_evr(should), yum_parse_evr(is)) < 0
+module RpmHelper
+
+  ARCH_LIST = [
+      'noarch',
+      'i386',
+      'i686',
+      'ppc',
+      'ppc64',
+      'armv3l',
+      'armv4b',
+      'armv4l',
+      'armv4tl',
+      'armv5tel',
+      'armv5tejl',
+      'armv6l',
+      'armv7l',
+      'm68kmint',
+      's390',
+      's390x',
+      'ia64',
+      'x86_64',
+      'sh3',
+      'sh4',
+    ]
+
+  ARCH_REGEX = Regexp.new(ARCH_LIST.join('|\.'))
+
+  # This is an attempt at implementing RPM's
+  # lib/rpmvercmp.c rpmvercmp(a, b) in Ruby.
+  #
+  # Some of the things in here look REALLY
+  # UGLY and/or arbitrary. Our goal is to
+  # match how RPM compares versions, quirks
+  # and all.
+  #
+  # I've kept a lot of C-like string processing
+  # in an effort to keep this as identical to RPM
+  # as possible.
+  #
+  # returns 1 if str1 is newer than str2,
+  #         0 if they are identical
+  #        -1 if str1 is older than str2
+  def rpmvercmp(str1, str2)
+    return 0 if str1 == str2
+
+    front_strip_re = /^[^A-Za-z0-9~]+/
+
+    while str1.length > 0 or str2.length > 0
+      # trim anything that's in front_strip_re and != '~' off the beginning of each string
+      str1 = str1.gsub(front_strip_re, '')
+      str2 = str2.gsub(front_strip_re, '')
+
+      # "handle the tilde separator, it sorts before everything else"
+      if /^~/.match(str1) && /^~/.match(str2)
+        # if they both have ~, strip it
+        str1 = str1[1..-1]
+        str2 = str2[1..-1]
+      elsif /^~/.match(str1)
+        return -1
+      elsif /^~/.match(str2)
+        return 1
+      end
+
+      break if str1.length == 0 or str2.length == 0
+
+      # "grab first completely alpha or completely numeric segment"
+      isnum = false
+      # if the first char of str1 is a digit, grab the chunk of continuous digits from each string
+      if /^[0-9]+/.match(str1)
+        if str1 =~ /^[0-9]+/
+          segment1 = $~.to_s
+          str1 = $~.post_match
+        else
+          segment1 = ''
+        end
+        if str2 =~ /^[0-9]+/
+          segment2 = $~.to_s
+          str2 = $~.post_match
+        else
+          segment2 = ''
+        end
+        isnum = true
+      # else grab the chunk of continuous alphas from each string (which may be '')
+      else
+        if str1 =~ /^[A-Za-z]+/
+          segment1 = $~.to_s
+          str1 = $~.post_match
+        else
+          segment1 = ''
+        end
+        if str2 =~ /^[A-Za-z]+/
+          segment2 = $~.to_s
+          str2 = $~.post_match
+        else
+          segment2 = ''
+        end
+      end
+
+      # if the segments we just grabbed from the strings are different types (i.e. one numeric one alpha),
+      # where alpha also includes ''; "numeric segments are always newer than alpha segments"
+      if segment2.length == 0
+        return 1 if isnum
+        return -1
+      end
+
+      if isnum
+        # "throw away any leading zeros - it's a number, right?"
+        segment1 = segment1.gsub(/^0+/, '')
+        segment2 = segment2.gsub(/^0+/, '')
+        # "whichever number has more digits wins"
+        return 1 if segment1.length > segment2.length
+        return -1 if segment1.length < segment2.length
+      end
+
+      # "strcmp will return which one is greater - even if the two segments are alpha
+      # or if they are numeric. don't return if they are equal because there might
+      # be more segments to compare"
+      rc = segment1 <=> segment2
+      return rc if rc != 0
+    end #end while loop
+
+    # if we haven't returned anything yet, "whichever version still has characters left over wins"
+    if str1.length > str2.length
+      return 1
+    elsif str1.length < str2.length
+      return -1
+    else
+      return 0
+    end
+  end
+
+  # parse a rpm "version" specification
+  # this re-implements rpm's
+  # rpmUtils.miscutils.stringToVersion() in ruby
+  def rpm_parse_evr(s)
+    ei = s.index(':')
+    if ei
+      e = s[0,ei]
+      s = s[ei+1,s.length]
+    else
+      e = nil
+    end
+    begin
+      e = String(Integer(e))
+    rescue
+      # If there are non-digits in the epoch field, default to nil
+      e = nil
+    end
+    ri = s.index('-')
+    if ri
+      v = s[0,ri]
+      r = s[ri+1,s.length]
+      if arch = r.scan(ARCH_REGEX)[0]
+        a = arch.gsub(/\./, '')
+        r.gsub!(ARCH_REGEX, '')
+      end
+    else
+      v = s
+      r = nil
+    end
+    return { :epoch => e, :version => v, :release => r, :arch => a }
+  end
+
+  # how rpm compares two package versions:
+  # rpmUtils.miscutils.compareEVR(), which massages data types and then calls
+  # rpm.labelCompare(), found in rpm.git/python/header-py.c, which
+  # sets epoch to 0 if null, then compares epoch, then ver, then rel
+  # using compare_values() and returns the first non-0 result, else 0.
+  # This function combines the logic of compareEVR() and labelCompare().
+  #
+  # "version_should" can be v, v-r, or e:v-r.
+  # "version_is" will always be at least v-r, can be e:v-r
+  def rpm_compareEVR(should_hash, is_hash)
+    # pass on to rpm labelCompare
+
+    if !should_hash[:epoch].nil?
+      rc = compare_values(should_hash[:epoch], is_hash[:epoch])
+      return rc unless rc == 0
+    end
+
+    rc = compare_values(should_hash[:version], is_hash[:version])
+    return rc unless rc == 0
+
+    # here is our special case, PUP-1244.
+    # if should_hash[:release] is nil (not specified by the user),
+    # and comparisons up to here are equal, return equal. We need to
+    # evaluate to whatever level of detail the user specified, so we
+    # don't end up upgrading or *downgrading* when not intended.
+    #
+    # This should NOT be triggered if we're trying to ensure latest.
+    return 0 if should_hash[:release].nil?
+
+    rc = compare_values(should_hash[:release], is_hash[:release])
+
+    return rc
+  end
+
+  # this method is a native implementation of the
+   # compare_values function in rpm's python bindings,
+   # found in python/header-py.c, as used by rpm.
+   def compare_values(s1, s2)
+     if s1.nil? && s2.nil?
+       return 0
+     elsif ( not s1.nil? ) && s2.nil?
+       return 1
+     elsif s1.nil? && (not s2.nil?)
+       return -1
+     end
+     return rpmvercmp(s1, s2)
+   end
+end

--- a/app/models/import/packages/gems.rb
+++ b/app/models/import/packages/gems.rb
@@ -6,9 +6,6 @@ class Import::Packages::Gems
   require 'yaml'
   require 'rubygems'
   require 'logger'
-  require 'activerecord-import'
-  require 'activerecord-import/base'
-  ActiveRecord::Import.require_adapter('pg')
 
   LOGFILE       = 'log/import.log'.freeze
   LOGLEVEL      = Logger::INFO

--- a/app/models/import/packages/yum/centos.rb
+++ b/app/models/import/packages/yum/centos.rb
@@ -9,9 +9,6 @@ class Import
         require 'find'
         require 'yaml'
         require 'logger'
-        require 'activerecord-import'
-        require 'activerecord-import/base'
-        ActiveRecord::Import.require_adapter('pg')
 
         LOGFILE       = 'log/import.log'.freeze
         LOGLEVEL      = Logger::INFO

--- a/app/models/import/servers.rb
+++ b/app/models/import/servers.rb
@@ -2,9 +2,6 @@
 class Import::Servers
   require 'yaml'
   require 'logger'
-  require 'activerecord-import'
-  require 'activerecord-import/base'
-  ActiveRecord::Import.require_adapter('pg')
 
   SERVER_FILES  = '/var/lib/package-reports/*.yaml'.freeze
   LOGFILE       = 'log/import.log'.freeze


### PR DESCRIPTION
* Replaced the rpm gem with native code (borrowed from puppet) to avoid
rpmlib dependencies.
* Updated the gem for activerecord-import to a version that doesn't
require manual includes, and thus plays better with switching db types.