### PR TITLE
Remove capistrano lock

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,3 @@
-# config valid only for current version of Capistrano
-lock '3.8.1'
-
 set :application, 'server-reports'
 set :repo_url, 'http://github.com/sul-dlss/system-package-tracker.git'
 


### PR DESCRIPTION
  Cap complained about the lock on the latest deploy of master.
  We haven't found these useful overall and have deleted them 
  in other projects as a convention.